### PR TITLE
Binance changes

### DIFF
--- a/src/binance.nim
+++ b/src/binance.nim
@@ -214,7 +214,9 @@ proc updateUserWallet(self: var Binance) =
   let wallet = parseJson(self.getContent(self.accountData))["balances"]
   self.balances = initTable[string, tuple[free: float, locked: float]]()
   for asset in wallet: 
-    self.balances[asset["asset"].getStr] = (asset["free"].getStr.parseFloat, asset["locked"].getStr.parseFloat)
+    # Hide 0 balances
+    if asset["free"].getStr.parseFloat != 0.0:
+      self.balances[asset["asset"].getStr] = (asset["free"].getStr.parseFloat, asset["locked"].getStr.parseFloat)
 
 
 proc exchangeInfo*(self: Binance, symbols: seq[string] = @[], fromMemory: bool = false): string =

--- a/src/binance.nim
+++ b/src/binance.nim
@@ -9,6 +9,16 @@ type
     balances: Table[string, tuple[free: float, locked: float]]
     exchangeData: string
 
+  FilterRule = enum
+    PRICE_FILTER        = "PRICE_FILTER"        ## Defines the price rules for a symbol
+    PERCENT_PRICE       = "PERCENT_PRICE"       ## Defines valid range for a price based on the average of the previous trades
+    LOT_SIZE            = "LOT_SIZE"            ## Defines the quantity (aka "lots" in auction terms) rules for a symbol
+    MIN_NOTIONAL        = "MIN_NOTIONAL"        ##   
+    ICEBERG_PARTS       = "ICEBERG_PARTS"       ##
+    MARKET_LOT_SIZE     = "MARKET_LOT_SIZE"     ##
+    MAX_NUM_ORDERS      = "MAX_NUM_ORDERS"      ##
+    MAX_NUM_ALGO_ORDERS = "MAX_NUM_ALGO_ORDERS" ##
+
   HistoricalKlinesType* = enum
     SPOT    = 1
     FUTURES = 2
@@ -263,6 +273,9 @@ proc userWallet*(self: var Binance, update:bool = false): self.balances.type =
   if update: 
     self.updateUserWallet
   self.balances
+
+
+proc verifyFiltersRule(filter: FilterRule):int = 0
 
 # Generic endpoints.
 

--- a/src/binance.nim
+++ b/src/binance.nim
@@ -232,7 +232,9 @@ proc exchangeInfo*(self: Binance, symbols: seq[string] = @[], fromMemory: bool =
         result.add symbols.join(",").replace(",","%22%2C%22")
         result.add "%22%5D"
   else:
+    result = self.exchangeData.parseJson.pretty
     if len(symbols) != 0:
+      result = ""
       var temp_result = (self.exchangeData.parseJson)["symbols"]
       var fetched:seq[string]
       for symbol in symbols:
@@ -240,9 +242,6 @@ proc exchangeInfo*(self: Binance, symbols: seq[string] = @[], fromMemory: bool =
           if k["symbol"].getStr notin fetched and k["symbol"].getStr == symbol:
             fetched.add symbol
             result.add k.pretty
-    else:
-      result = self.exchangeData.parseJson.pretty
-      
 
     
 proc newBinance*(apiKey, apiSecret: string): Binance =

--- a/src/binance.nim
+++ b/src/binance.nim
@@ -242,10 +242,18 @@ proc time*(self: Binance): string =
   result = binanceAPIUrl & "/api/v3/time"
 
 
-proc exchangeInfo*(self: Binance): string =
+proc exchangeInfo*(self: Binance, symbols:seq[string] = @[]): string =
   ## Exchange information, info about Binance.
   result = binanceAPIUrl & "/api/v3/exchangeInfo"
-
+  if len(symbols) != 0:
+    if len(symbols) == 1:
+      result.add "?symbol="
+      result.add symbols[0]
+    else:
+      result.add "?symbols="
+      result.add "%5B%22"
+      result.add symbols.join(",").replace(",","%22%2C%22")
+      result.add "%22%5D"
 
 # Market Data Endpoints
 


### PR DESCRIPTION
* exchangeInfo sigue retornando un string, si no se usa el parámetro fromMemory la data será consultada en el endpoint api/v3/exchangeInfo, 
* userWallet y exchangeData están disponibles en runtime sin necesidad de consultar más de una vez sus endpoint, a menos que requiera un refreshLoad o similar
* se ocultan los assets en 0 en la billetera, para ahorrar memoria con los coins usados realmente por el usuario.
* filterRules sigue en proceso