### PR TITLE
updated prepareTransactions

### DIFF
--- a/src/binance.nim
+++ b/src/binance.nim
@@ -150,7 +150,7 @@ type
 
 
 const binanceAPIUrl* {.strdefine.} = "https://api.binance.com"  ## `-d:binanceAPIUrl="https://testnet.binance.vision"` for Testnet.
-
+const stableCoins* = ["USDT", "BUSD", "DAI", "USDC", "TUSD", "PAX"]
 
 template checkFloat*(floaty: float; lowest: static[float] = NaN; highest: static[float] = NaN) =
   ## Utility template to check if a float is valid, because float sux.

--- a/src/binance.nim
+++ b/src/binance.nim
@@ -13,6 +13,10 @@ type
   MarketCap*    = seq[tuple[marketCap: int, ticker: string]]
   TradingInfo*  = tuple[baseAsset, quoteAsset: string, price, amount: float]
 
+  CoinType = enum
+    STABLE_COIN = "STABLE_COIN"
+    ALT_COIN    = "ALT_COIN"
+
   FilterRule = enum
     PRICE_FILTER        = "PRICE_FILTER"        ## Defines the price rules for a symbol
     PERCENT_PRICE       = "PERCENT_PRICE"       ## Defines valid range for a price based on the average of the previous trades
@@ -290,7 +294,7 @@ proc userWallet*(self: var Binance, update:bool = false): self.balances.type =
   self.balances
 
 
-proc getStableCoinsInWallet(self: var Binance): Table[string, float] =
+proc getStableCoinsInWallet*(self: var Binance): Table[string, float] =
   var myWallet = self.userWallet(update = true)
   for coin in myWallet.keys:
     if coin in stableCoins:

--- a/src/binance.nim
+++ b/src/binance.nim
@@ -290,11 +290,11 @@ proc userWallet*(self: var Binance, update:bool = false): self.balances.type =
   self.balances
 
 
-proc getStableCoinsInWallet(self: var Binance): seq[tuple[coin: string, free: float]] =
+proc getStableCoinsInWallet(self: var Binance): Table[string, float] =
   var myWallet = self.userWallet(update = true)
   for coin in myWallet.keys:
     if coin in stableCoins:
-      result.add ( coin, myWallet[coin].free )
+      result[coin] = myWallet[coin].free
 
 
 proc verifyFiltersRule(self:Binance, symbol: string, price, quantity:float, tipe: OrderType):bool =

--- a/src/binance.nim
+++ b/src/binance.nim
@@ -290,6 +290,11 @@ proc userWallet*(self: var Binance, update:bool = false): self.balances.type =
   self.balances
 
 
+proc getStableCoinsInWallet(self: var Binance): seq[tuple[coin: string, free: float]] =
+  var myWallet = self.userWallet(update = true)
+  for coin in myWallet.keys:
+    if coin in stableCoins:
+      result.add ( coin, myWallet[coin].free )
 
 
 proc verifyFiltersRule(self:Binance, symbol: string, price, quantity:float, tipe: OrderType):bool =


### PR DESCRIPTION
* Se puede pasar STABLE_COIN como parametro en prepareTransactions, para generar todos los trades posibles usando las stable coins en la wallet del usuario
* Amount dinámico en base al precio en tickerPrice
* formatFloat(ffDecimal, 4) puede usarse para remplazar tanto round y truncate, ya que produce la salida deseada para amount/quantity de 4 decimales, y para precios con 2 decimales de precision.
* Todas las transacciones del primer punto que tengan estatus PREPARED, podrán ser enviadas sin problemas usando orderPost, si el estatus es WITHOUT_FUNDS, se omiten esas transacciones

![image](https://user-images.githubusercontent.com/55286192/157371019-5d25ef29-aca2-4be0-b5be-0e3a534ff2f1.png)
