### PR TITLE
update

### DIFF
--- a/src/binance.nim
+++ b/src/binance.nim
@@ -930,6 +930,19 @@ proc borrow*(self: Binance, asset: string, amount: float, accountType: AccountTy
 
   self.signQueryString("margin/loan", sapi = true)
 
+proc repay*(self: Binance, asset: string, amount: float, accountType: AccountType): string =
+  result.add "asset="
+  result.add asset
+  result.add "&amount="
+  result.add $amount
+
+  if accountType == ISOLATED_ACCOUNT:
+    result.add "&isIsolated=TRUE"
+    result.add "&symbol="
+    result.add self.marginAsset
+
+  self.signQueryString("margin/repay", sapi = true)
+
 
 runnableExamples"-d:ssl -d:nimDisableCertificateValidation -r:off":
   let client: Binance = newBinance("YOUR_BINANCE_API_KEY", "YOUR_BINANCE_API_SECRET")

--- a/src/binance.nim
+++ b/src/binance.nim
@@ -917,6 +917,20 @@ proc transfer*(self: Binance, asset: string, amount: float, tipe: AssetTransfer)
   result.add if tipe == SPOT_TO_MARGIN_CROSS: "1" else: "2"
   self.signQueryString("margin/transfer", sapi = true)
 
+proc borrow*(self: Binance, asset: string, amount: float, accountType: AccountType): string =
+  result.add "asset="
+  result.add asset
+  result.add "&amount="
+  result.add $amount
+
+  if accountType == ISOLATED_ACCOUNT:
+    result.add "&isIsolated=TRUE"
+    result.add "&symbol="
+    result.add self.marginAsset
+
+  self.signQueryString("margin/loan", sapi = true)
+
+
 runnableExamples"-d:ssl -d:nimDisableCertificateValidation -r:off":
   let client: Binance = newBinance("YOUR_BINANCE_API_KEY", "YOUR_BINANCE_API_SECRET")
   let preparedEndpoint: string = client.ping()

--- a/src/binance.nim
+++ b/src/binance.nim
@@ -574,8 +574,6 @@ proc getOrder*(self: Binance, symbol: string, orderId = 1.Positive, origClientOr
 #Send in a new order.
 proc postOrder*(self: var Binance; side: Side; tipe: OrderType; timeInForce, symbol: string; quantity, price: float): string =
   self.prechecks = self.verifyFiltersRule(symbol, price, quantity, tipe)
-  echo quantity.formatFloat(ffDecimal, 4)
-
   result = "symbol="
   result.add symbol
   result.add "&side="
@@ -583,7 +581,7 @@ proc postOrder*(self: var Binance; side: Side; tipe: OrderType; timeInForce, sym
   result.add "&type="
   result.add $tipe
   result.add "&quantity="
-  result.add quantity.formatFloat(ffDecimal, 4)
+  result.add quantity.formatFloat(ffDecimal, 8)
 
   if tipe == ORDER_TYPE_LIMIT:
     result.add "&timeInForce="
@@ -602,13 +600,13 @@ proc postOrder*(self: Binance; side: Side; tipe: OrderType; symbol: string; quan
   result.add "&type="
   result.add $tipe
   result.add "&quantity="
-  result.add quantity.formatFloat(ffDecimal, 4)
+  result.add quantity.formatFloat(ffDecimal, 8)
   result.add "&price="
   result.add price.formatFloat(ffDecimal, 2)
   self.signQueryString"order"
 
 
-proc postOrder*(self: Binance; side: Side; tipe: OrderType; symbol: string; quantity: float): string =
+proc postOrder*(self: Binance; side: Side; tipe: OrderType; symbol: string; quantity: float; accountType: AccountType = SPOT_ACCOUNT): string =
   result = "symbol="
   result.add symbol
   result.add "&side="
@@ -616,8 +614,12 @@ proc postOrder*(self: Binance; side: Side; tipe: OrderType; symbol: string; quan
   result.add "&type="
   result.add $tipe
   result.add "&quantity="
-  result.add quantity.formatFloat(ffDecimal, 4)
-  self.signQueryString"order"
+  result.add quantity.formatFloat(ffDecimal, 8)
+  result.add "&isIsolated="
+  result.add if accountType == ISOLATED_ACCOUNT: "TRUE" else: "FALSE"
+  case accountType:
+  of SPOT_ACCOUNT: self.signQueryString"order"
+  of MARGIN_ACCOUNT, ISOLATED_ACCOUNT: self.signQueryString("margin/order", sapi = true)
 
 
 #POST /api/v3/order/test

--- a/src/binance.nim
+++ b/src/binance.nim
@@ -228,7 +228,7 @@ template getContent*(self: Binance, url: string): string = self.client.getConten
 proc request*(self: Binance, endpoint: string, httpMethod: HttpMethod = HttpGet): string {.inline.} = self.client.request(url = endpoint, httpMethod = httpMethod).body
 
 
-template signQueryString(self: Binance; endpoint: static[string], sapi: bool = false) =
+template signQueryString(self: Binance; endpoint: string, sapi: bool = false) =
   ## Sign the query string for Binance API, reusing the same string.
   result.add if len(result) > 0: "&recvWindow=" else: "recvWindow="
   result.addInt self.recvWindow
@@ -237,7 +237,7 @@ template signQueryString(self: Binance; endpoint: static[string], sapi: bool = f
   let signature: string = sha256.hmac(self.apiSecret, result)
   result.add "&signature="
   result.add signature
-  result = static(binanceAPIUrl & (if not sapi: "/api/v3/" else: "/sapi/v1/") & endpoint & '?') & result
+  result = binanceAPIUrl & (if not sapi: "/api/v3/" else: "/sapi/v1/") & endpoint & '?' & result
 
 #GET /{s}api/v3/account
 #Get the current account information
@@ -924,6 +924,8 @@ proc transfer*(self: Binance, asset: string, amount: float, tipe: AssetTransfer)
     result.add if tipe == SPOT_TO_MARGIN_CROSS: "1" else: "2"
   else:
     url = "margin/isolated/transfer"  
+    result.add "&symbol="
+    result.add self.marginAsset
     result.add "&transFrom="
     result.add if tipe == SPOT_TO_MARGIN_ISOLATED: "SPOT" else: "ISOLATED_MARGIN"
     result.add "&transTo="


### PR DESCRIPTION
La propiedad marginAsset  se usará para definir el asset pair en el trade, actualmente solo es requerido para algunas funciones que usen el modo de margin_isolated, por lo que se accede directamente como self.marginAsset en vez de pasarla como parámetro a las funciones.

Transfer
    * SPOT <-> MARGIN_CROSS
    * SPOT <-> MARGIN_ISOLATED
   
postOrder/Borrow/Repay habilitado para margin_cross/margin_isolated
    
 
  

